### PR TITLE
盗難記事のバリデーションを追加

### DIFF
--- a/app/forms/post_form.rb
+++ b/app/forms/post_form.rb
@@ -12,16 +12,25 @@ class PostForm
   attribute :user_id, :integer
   attribute :post
 
+  validates :car_name, presence: true, length: { maximum: 50 }
+  validates :car_number, presence: true, length: { maximum: 50 }
+  validates :stole_location, presence: true
+  validates :images, presence: true
+
+  validate :check_image
+  validate :image_count
+
   def save
     return false if invalid?
 
-    self.post = Post.new(post_params) # newがcreateじゃね？
-    post.save
+    ActiveRecord::Base.transaction do
+      self.post = Post.new(post_params) # newがcreateじゃね？
+      post.save
 
-    images.each do |image|
-      post.images.create!(image: image)
+      images.each do |image|
+        post.images.create!(image: image)
+      end
     end
-
     true
   end
 
@@ -37,5 +46,24 @@ class PostForm
       stole_time: stole_time,
       user_id: user_id
     }
+  end
+
+  def check_image
+    return false if images.blank?
+
+    extension_allowlist = %w[image/jpg image/jpeg image/png]
+    images&.each do |image|
+      if !extension_allowlist.include?(image.content_type)
+        errors.add(:images, 'は jpg/jpeg/png のみアップロードできます')
+      elsif image.size > 3.megabyte
+        errors.add(:images, '3MBまでアップロードできます')
+      end
+    end
+  end
+
+  def image_count
+    return false if images.blank?
+
+    errors.add('画像は5枚までです') if images.count >= 6
   end
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -37,7 +37,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Add an allowlist of extensions which are allowed to be uploaded.
   # For images you might use something like this:
   def extension_allowlist
-    %w[jpg jpeg gif png]
+    %w[jpg jpeg png]
   end
 
   # Override the filename of the uploaded files:


### PR DESCRIPTION
Resolves #45 
盗難記事（Post、Imageモデル）にバリデーションを追加
・画像のアップロード数は1枚以上5枚以下
・画像1枚の容量は3MB
・画像の拡張子はjpg/jpeg/png限定

二つのモデルの両方のバリデーションが通らないと記事を登録できないように、
トランザクションを追加