### PR TITLE
【FIX】未ログインの許可ページ修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,6 @@
 class PostsController < ApplicationController
+  skip_before_action :require_login, only: %i[index show]
+
   def index
     @posts = Post.all.includes(:user, :images).order(created_at: :desc)
   end


### PR DESCRIPTION
Resolves #50 
未ログインでも盗難情報を閲覧できるように変更
今後実装する盗難情報詳細ページも追加