### PR TITLE
rubocopの設定編集

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -105,6 +105,9 @@ Metrics/AbcSize:
   Enabled: true
   Max: 20
 
+Metrics/MethodLength:
+  Max: 14
+
 Naming/InclusiveLanguage:
   FlaggedTerms:
     offence:


### PR DESCRIPTION
rubocopのメソッドの行数を10行から14行に修正