### PR TITLE
ラインで画像を複数送信できるように修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -151,9 +151,10 @@ class PostsController < ApplicationController
             type: 'image',
             url: img.to_s,
             size: 'full',
-            aspectMode: 'cover',
+            aspectMode: 'fit',
             aspectRatio: '1:1',
-            gravity: 'center'
+            gravity: 'center',
+            action: { type: 'uri', uri: img.image.url.to_s }
           }
         ],
         paddingAll: '0px'

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -55,12 +55,29 @@ class PostsController < ApplicationController
     end
   end
 
+  # def line_carousel(form)
+  #   bubbles = []
+  #   bubbles.push line_bubble(form)
+  #   if form.images.count >= 2
+  #     (form.post.images[1].image.url..form.post.images.last.image.url).each do |img|
+  #       binding.pry
+  #       bubbles.push image_bubble(img)
+  #     end
+  #   end
+
+  #   {
+  #     type: 'carousel',
+  #     contents: bubbles
+  #   }
+  # end
+
   def line_carousel(form)
     bubbles = []
-    bubbles.push line_bubble(form)
-    if form.images.count >= 2
-      (form.post.images[1].image.url..form.post.images.last.image.url).each do |img|
-        bubbles.push image_bubble(img)
+    form.post.images.each_with_index do |img, i|
+      if i == 0
+        bubbles.push line_bubble(form)
+      else
+        bubbles.push image_bubble(img.image.url)
       end
     end
     {
@@ -135,7 +152,7 @@ class PostsController < ApplicationController
             url: img.to_s,
             size: 'full',
             aspectMode: 'cover',
-            aspectRatio: '2:3',
+            aspectRatio: '4:3',
             gravity: 'top'
           }
         ],

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,4 @@
-class PostsController < ApplicationController
+class PostsController < ApplicationController # rubocop:disable Metrics/ClassLength
   skip_before_action :require_login, only: %i[index show]
 
   def index
@@ -55,35 +55,16 @@ class PostsController < ApplicationController
     end
   end
 
-  # def line_carousel(form)
-  #   bubbles = []
-  #   bubbles.push line_bubble(form)
-  #   if form.images.count >= 2
-  #     (form.post.images[1].image.url..form.post.images.last.image.url).each do |img|
-  #       binding.pry
-  #       bubbles.push image_bubble(img)
-  #     end
-  #   end
-
-  #   {
-  #     type: 'carousel',
-  #     contents: bubbles
-  #   }
-  # end
-
   def line_carousel(form)
     bubbles = []
     form.post.images.each_with_index do |img, i|
-      if i == 0
+      if i.zero?
         bubbles.push line_bubble(form)
       else
         bubbles.push image_bubble(img.image.url)
       end
     end
-    {
-      type: 'carousel',
-      contents: bubbles
-    }
+    { type: 'carousel', contents: bubbles }
   end
 
   def line_bubble(form)
@@ -99,9 +80,7 @@ class PostsController < ApplicationController
     {
       type: 'image',
       url: form.post.images[0].image.url.to_s,
-      size: 'full',
-      aspectRatio: '4:3',
-      aspectMode: 'cover',
+      size: 'full', aspectRatio: '4:3', aspectMode: 'cover',
       action: { type: 'uri', uri: form.post.images[0].image.url.to_s }
     }
   end
@@ -144,16 +123,11 @@ class PostsController < ApplicationController
     {
       type: 'bubble',
       body: {
-        type: 'box',
-        layout: 'vertical',
+        type: 'box', layout: 'vertical',
         contents: [
           {
-            type: 'image',
-            url: img.to_s,
-            size: 'full',
-            aspectMode: 'cover',
-            aspectRatio: '1:1',
-            gravity: 'center',
+            type: 'image', url: img.to_s, size: 'full',
+            aspectMode: 'cover', aspectRatio: '1:1', gravity: 'center',
             action: { type: 'uri', label: 'action', uri: img.to_s }
           }
         ],

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -13,7 +13,6 @@ class PostsController < ApplicationController
     @form = PostForm.new(post_params)
     if @form.save
       message = { type: 'flex', altText: '盗難車両', contents: line_carousel(@form) }
-      binding.pry
       client.broadcast(message)
       redirect_to root_path
     else

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -152,8 +152,8 @@ class PostsController < ApplicationController
             url: img.to_s,
             size: 'full',
             aspectMode: 'cover',
-            aspectRatio: '4:3',
-            gravity: 'top'
+            aspectRatio: '1:1',
+            gravity: 'center'
           }
         ],
         paddingAll: '0px'

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -12,7 +12,7 @@ class PostsController < ApplicationController
   def create
     @form = PostForm.new(post_params)
     if @form.save
-      message = { type: 'flex', altText: '盗難車両', contents: line_bubble(@form) }
+      message = { type: 'flex', altText: '盗難車両', contents: line_carousel(@form) }
       client.broadcast(message)
       redirect_to root_path
     else
@@ -55,7 +55,7 @@ class PostsController < ApplicationController
     end
   end
 
-  def set_carousel(form)
+  def line_carousel(form)
     bubbles = []
     bubbles.push line_bubble(form)
     if form.post.images.count >= 2

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -151,10 +151,10 @@ class PostsController < ApplicationController
             type: 'image',
             url: img.to_s,
             size: 'full',
-            aspectMode: 'fit',
+            aspectMode: 'cover',
             aspectRatio: '1:1',
             gravity: 'center',
-            action: { type: 'uri', uri: img.image.url.to_s }
+            action: { type: 'uri', label: 'action', uri: img.to_s }
           }
         ],
         paddingAll: '0px'

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -132,7 +132,7 @@ class PostsController < ApplicationController
         contents: [
           {
             type: 'image',
-            url: img,
+            url: img.to_s,
             size: 'full',
             aspectMode: 'cover',
             aspectRatio: '2:3',

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -55,6 +55,20 @@ class PostsController < ApplicationController
     end
   end
 
+  def set_carousel(form)
+    bubbles = []
+    bubbles.push line_bubble(form)
+    if form.post.images.count >= 2
+      (form.post.images[1]..form.post.images.last).map do |image|
+        bubbles.push image_bubble(image)
+      end
+    end
+    {
+      type: 'carousel',
+      contents: bubbles
+    }
+  end
+
   def line_bubble(form)
     {
       type: 'bubble',
@@ -106,6 +120,27 @@ class PostsController < ApplicationController
         { type: 'spacer', size: 'sm' }
       ],
       flex: 0
+    }
+  end
+
+  def image_bubble(image)
+    {
+      type: 'bubble',
+      body: {
+        type: 'box',
+        layout: 'vertical',
+        contents: [
+          {
+            type: 'image',
+            url: image.image.url.to_s,
+            size: 'full',
+            aspectMode: 'cover',
+            aspectRatio: '2:3',
+            gravity: 'top'
+          }
+        ],
+        paddingAll: '0px'
+      }
     }
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -13,6 +13,7 @@ class PostsController < ApplicationController
     @form = PostForm.new(post_params)
     if @form.save
       message = { type: 'flex', altText: '盗難車両', contents: line_carousel(@form) }
+      binding.pry
       client.broadcast(message)
       redirect_to root_path
     else
@@ -58,9 +59,9 @@ class PostsController < ApplicationController
   def line_carousel(form)
     bubbles = []
     bubbles.push line_bubble(form)
-    if form.post.images.count >= 2
-      (form.post.images[1]..form.post.images.last).map do |image|
-        bubbles.push image_bubble(image)
+    if form.images.count >= 2
+      (form.post.images[1].image.url..form.post.images.last.image.url).each do |img|
+        bubbles.push image_bubble(img)
       end
     end
     {
@@ -123,7 +124,7 @@ class PostsController < ApplicationController
     }
   end
 
-  def image_bubble(image)
+  def image_bubble(img)
     {
       type: 'bubble',
       body: {
@@ -132,7 +133,7 @@ class PostsController < ApplicationController
         contents: [
           {
             type: 'image',
-            url: image.image.url.to_s,
+            url: img,
             size: 'full',
             aspectMode: 'cover',
             aspectRatio: '2:3',


### PR DESCRIPTION
Resolves #38 
盗難情報登録時にラインで送信する画像を、複数枚送信できるように修正